### PR TITLE
feat: add answer dto

### DIFF
--- a/travel-api/travel-api-business/travel-api-answer/src/main/java/cn/wolfcode/wolf2w/business/api/domain/dto/AnswerDTO.java
+++ b/travel-api/travel-api-business/travel-api-answer/src/main/java/cn/wolfcode/wolf2w/business/api/domain/dto/AnswerDTO.java
@@ -1,0 +1,23 @@
+package cn.wolfcode.wolf2w.business.api.domain.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import lombok.Data;
+
+/**
+ * DTO for answer creation or update.
+ */
+@Data
+public class AnswerDTO {
+    /** Question identifier. */
+    @NotNull(message = "问题ID不能为空")
+    private Long questionId;
+
+    /** Answer content. */
+    @NotBlank(message = "内容不能为空")
+    private String content;
+
+    /** Whether the answer is a draft. */
+    private Boolean draft;
+}


### PR DESCRIPTION
## Summary
- add DTO for handling answers with validation support

## Testing
- `mvn -q -pl travel-api/travel-api-business/travel-api-answer -am test` *(fails: Non-resolvable import POM: Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_6890720a905883308f635fd43c017c69