### PR TITLE
Use Collections.emptyList for Java 8 compatibility

### DIFF
--- a/travel-modules/travel-modules-business/travel-modules-answer/src/main/java/cn/wolfcode/wolf2w/business/controller/DestinationBffController.java
+++ b/travel-modules/travel-modules-business/travel-modules-answer/src/main/java/cn/wolfcode/wolf2w/business/controller/DestinationBffController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -28,6 +29,6 @@ public class DestinationBffController {
                 + ", size=" + (r==null||r.getData()==null?0:r.getData().size()));
 
         // 只要下游返回了数据，统一按 200 返回，前端就会渲染
-        return R.ok(r != null && r.getData() != null ? r.getData() : List.of());
+        return R.ok(r != null && r.getData() != null ? r.getData() : Collections.emptyList());
     }
 }


### PR DESCRIPTION
## Summary
- replace Java 9 `List.of` usage with `Collections.emptyList` in DestinationBffController for Java 8 compatibility

## Testing
- `mvn -q -pl travel-modules/travel-modules-business/travel-modules-answer -am test` *(fails: Non-resolvable import POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689075535d18833094faf4493c9775e1