### PR TITLE
fix: add children field to destination dto

### DIFF
--- a/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
+++ b/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
@@ -1,10 +1,17 @@
 package cn.wolfcode.wolf2w.business.api.domain.DTO;
 
 import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class DestinationDTO {
     private Long id;
     private String name;
+    /**
+     * Child destinations used for building a destination tree.
+     * Initialized to an empty list to avoid null checks on the frontend.
+     */
+    private List<DestinationDTO> children = new ArrayList<>();
 
 }


### PR DESCRIPTION
## Summary
- add children list to DestinationDTO to support destination selection tree

## Testing
- `mvn -q -pl travel-api/travel-api-business/travel-api-destination -am test` *(fails: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68907730baa48330ab991bd4fce099e2