### PR TITLE
fix: return destination tree for feign list

### DIFF
--- a/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
+++ b/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
@@ -1,10 +1,17 @@
 package cn.wolfcode.wolf2w.business.api.domain.DTO;
 
 import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class DestinationDTO {
     private Long id;
     private String name;
+    /**
+     * Child destinations used for building a destination tree.
+     * Initialized to an empty list to avoid null checks on the frontend.
+     */
+    private List<DestinationDTO> children = new ArrayList<>();
 
 }

--- a/travel-modules/travel-modules-business/travel-modules-destination/src/main/java/cn/wolfcode/wolf2w/business/controller/DestinationController.java
+++ b/travel-modules/travel-modules-business/travel-modules-destination/src/main/java/cn/wolfcode/wolf2w/business/controller/DestinationController.java
@@ -6,6 +6,7 @@ import cn.wolfcode.wolf2w.business.service.IRegionService;
 import cn.wolfcode.wolf2w.common.core.domain.R;
 import cn.wolfcode.wolf2w.common.security.annotation.InnerAuth;
 import cn.wolfcode.wolf2w.business.api.domain.Destination;
+import cn.wolfcode.wolf2w.business.api.domain.DTO.DestinationDTO;
 import cn.wolfcode.wolf2w.business.query.DestinationQuery;
 import cn.wolfcode.wolf2w.business.service.IDestinationService;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 目的地 Controller
@@ -82,8 +84,22 @@ public class DestinationController {
      * Feign 接口
      */
     @GetMapping("/feign/list")
-    public R<List<Destination>> feignList() {
-        return R.ok(destinationService.list());
+    public R<List<DestinationDTO>> feignList() {
+        List<Destination> list = destinationService.list();
+        List<DestinationDTO> dtoList = list.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return R.ok(dtoList);
+    }
+
+    private DestinationDTO toDto(Destination dest) {
+        DestinationDTO dto = new DestinationDTO();
+        dto.setId(dest.getId());
+        dto.setName(dest.getName());
+        if (dest.getChildren() != null) {
+            dest.getChildren().forEach(child -> dto.getChildren().add(toDto(child)));
+        }
+        return dto;
     }
 
     @InnerAuth


### PR DESCRIPTION
## Summary
- ensure DestinationDTO always provides a `children` list for tree traversal
- return DestinationDTO tree from `/destinations/feign/list` so the frontend never receives undefined children

## Testing
- `mvn -q -pl travel-api/travel-api-business/travel-api-destination,travel-modules/travel-modules-business/travel-modules-destination -am test` *(fails: Non-resolvable import POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68907730baa48330ab991bd4fce099e2