### PR TITLE
fix: return destination tree for feign list

### DIFF
--- a/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
+++ b/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/DTO/DestinationDTO.java
@@ -1,10 +1,22 @@
 package cn.wolfcode.wolf2w.business.api.domain.DTO;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class DestinationDTO {
     private Long id;
     private String name;
+    /**
+     * Child destinations used for building a destination tree.
+     * Initialized to an empty list to avoid null checks on the frontend.
+     * The {@link JsonInclude} annotation forces serialization of the field
+     * even when the list is empty so the frontend never sees an undefined value.
+     */
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private List<DestinationDTO> children = new ArrayList<>();
 
 }


### PR DESCRIPTION
## Summary
- ensure DestinationDTO always provides a `children` list for tree traversal
- build hierarchical tree in `/destinations/feign/list` so each destination has proper `children`
- force JSON serialization to include empty `children` arrays so the frontend never receives `undefined`

## Testing
- `mvn -q -pl travel-api/travel-api-business/travel-api-destination,travel-modules/travel-modules-business/travel-modules-destination -am test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68907730baa48330ab991bd4fce099e2