### PR TITLE
fix: ensure destination children list

### DIFF
--- a/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/vo/DestinationOptionVO.java
+++ b/travel-api/travel-api-business/travel-api-destination/src/main/java/cn/wolfcode/wolf2w/business/api/domain/vo/DestinationOptionVO.java
@@ -1,10 +1,30 @@
 package cn.wolfcode.wolf2w.business.api.domain.vo;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 前端目的地选择器选项
+ * <p>
+ * "热门" 等列表返回的节点有时没有 children 字段，
+ * 为避免前端访问 node.children.length 时报错，
+ * 统一在 VO 中初始化一个空的 children 列表。
+ */
 @Data
-@AllArgsConstructor
+@NoArgsConstructor
 public class DestinationOptionVO {
     private Long id;
     private String name;
+    /**
+     * 子节点列表，默认为空数组，保证前端访问安全
+     */
+    private List<DestinationOptionVO> children = new ArrayList<>();
+
+    public DestinationOptionVO(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }


### PR DESCRIPTION
## Summary
- initialize `children` as an empty list in `DestinationOptionVO` so frontend selectors always receive a consistent structure

## Testing
- `mvn -q -pl travel-modules/travel-modules-business/travel-modules-destination -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689095bd9f4083308fdc103d2766b536