### PR TITLE
Handle remote data initialization failures in search service

### DIFF
--- a/travel-modules/travel-modules-business/travel-modules-search/src/main/java/cn/wolfcode/wolf2w/business/service/impl/DestinationEsServiceImpl.java
+++ b/travel-modules/travel-modules-business/travel-modules-search/src/main/java/cn/wolfcode/wolf2w/business/service/impl/DestinationEsServiceImpl.java
@@ -23,10 +23,13 @@ public class DestinationEsServiceImpl implements IDestinationEsService {
 
     @Override
     public void initData() {
-        R<List<Destination>> list = remoteDestinationService.list2(SecurityConstants.INNER);
-        log.info(list.getMsg()+"异常");
+        R<List<Destination>> result = remoteDestinationService.list2(SecurityConstants.INNER);
+        if (R.isError(result) || result.getData() == null) {
+            log.warn("获取目的地数据失败:{}", result.getMsg());
+            return;
+        }
         List<DestinationES> esList = new ArrayList<>();
-        for (Destination destination : list.getData()) {
+        for (Destination destination : result.getData()) {
             DestinationES es = new DestinationES();
             BeanUtils.copyProperties(destination, es);
             esList.add(es);

--- a/travel-modules/travel-modules-business/travel-modules-search/src/main/java/cn/wolfcode/wolf2w/business/service/impl/StrategyEsServiceImpl.java
+++ b/travel-modules/travel-modules-business/travel-modules-search/src/main/java/cn/wolfcode/wolf2w/business/service/impl/StrategyEsServiceImpl.java
@@ -6,14 +6,16 @@ import cn.wolfcode.wolf2w.business.api.domain.StrategyES;
 import cn.wolfcode.wolf2w.business.respository.StrategyEsRepository;
 import cn.wolfcode.wolf2w.business.service.IStrategyEsService;
 import cn.wolfcode.wolf2w.common.core.constant.SecurityConstants;
+import cn.wolfcode.wolf2w.common.core.domain.R;
 import cn.wolfcode.wolf2w.common.core.utils.bean.BeanUtils;
 import lombok.RequiredArgsConstructor;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class StrategyEsServiceImpl implements IStrategyEsService {
@@ -22,9 +24,13 @@ public class StrategyEsServiceImpl implements IStrategyEsService {
 
     @Override
     public void initData() {
-        List<Strategy> list = remoteStrategyService.list2(SecurityConstants.INNER).getData();
+        R<List<Strategy>> result = remoteStrategyService.list2(SecurityConstants.INNER);
+        if (R.isError(result) || result.getData() == null) {
+            log.warn("获取攻略数据失败:{}", result.getMsg());
+            return;
+        }
         List<StrategyES> esList = new ArrayList<>();
-        for (Strategy strategy : list) {
+        for (Strategy strategy : result.getData()) {
             StrategyES es = new StrategyES();
             BeanUtils.copyProperties(strategy, es);
             esList.add(es);


### PR DESCRIPTION
## Summary
- Safely handle missing remote strategy data during ES initialization
- Guard against null data when fetching destinations for ES indexing

## Testing
- `mvn -q -pl travel-modules/travel-modules-business/travel-modules-search -am test` *(fails: Unknown host maven.aliyun.com)*

------
https://chatgpt.com/codex/tasks/task_e_6891be3a6ee08330a693ab69cd0ce909